### PR TITLE
Scan for updated ClojureScript files as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ pom.xml
 docs/uberdoc.html
 /target
 foo.bar*
+/.lein-repl-history
+/.nrepl-port

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/uberdoc.html
 foo.bar*
 /.lein-repl-history
 /.nrepl-port
+/pom.xml.asc

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pom.xml
 .lein-deps-sum
 docs/uberdoc.html
 /target
+foo.bar*

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
-(defproject com.github.tranchis/lein-margauto "1.0.14"
+(defproject com.github.luskwater/lein-margauto "1.0.15-SNAPSHOT"
   :description "Leiningen plugin: Autobuilder and simple server for Marginalia documentation."
-  :plugins [[no-man-is-an-island/lein-eclipse "2.0.0"]]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[lein-marginalia "0.7.1"]])
+  :dependencies [[lein-marginalia "0.9.0"]]
+  :repositories [["releases" {:url "https://clojars.org/repo"
+                            :creds :gpg}]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.luskwater/lein-margauto "1.0.15"
+(defproject com.github.luskwater/lein-margauto "1.0.16-SNAPSHOT"
   :description "Leiningen plugin: Autobuilder and simple server for Marginalia documentation."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.luskwater/lein-margauto "1.0.16-SNAPSHOT"
+(defproject com.github.luskwater/lein-margauto "1.0.16"
   :description "Leiningen plugin: Autobuilder and simple server for Marginalia documentation."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.luskwater/lein-margauto "1.0.16"
+(defproject com.github.luskwater/lein-margauto "1.0.17-SNAPSHOT"
   :description "Leiningen plugin: Autobuilder and simple server for Marginalia documentation."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[lein-marginalia "0.9.0"]]
-  :repositories [["releases" {:url "https://clojars.org/repo"
-                            :creds :gpg}]])
+  :repositories [["releases" :clojars]]
+  :profiles {:provided {:dependencies [[org.clojure/clojure "1.8.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.luskwater/lein-margauto "1.0.15-SNAPSHOT"
+(defproject com.github.luskwater/lein-margauto "1.0.15"
   :description "Leiningen plugin: Autobuilder and simple server for Marginalia documentation."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[lein-marginalia "0.9.0"]]
-  :repositories [["releases" :clojars]]
+  :repositories [["releases" {:url "https://clojars.org/repo"
+                              :creds :gpg}]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.8.0"]]}})

--- a/src/leiningen/margauto.clj
+++ b/src/leiningen/margauto.clj
@@ -1,19 +1,41 @@
 (ns leiningen.margauto
+  "Automatically update Marginalia-generated documentation.
+
+  Monitor Clojure and ClojureScript files in specified directories,
+  updating at intervals when a source file changes."
   (:require [leiningen.marg :as lm]
             [clojure.tools.cli :as cli]))
 
-(defn source-files-seq [dirs]
+(def clojure-extensions
+  "Set of acceptable extensions for Clojure/ClojureScript"
+  #{".clj" ".cljs" ".cljc"})
+
+(defn ends-with-one-of
+  "The given string `s` ends with one of the strings in `coll`"
+  [coll s]
+  (letfn [(ends-with-this [suffix]
+            (.endsWith s suffix))]
+    (some ends-with-this coll)))
+
+(defn source-files-seq
+  "Return Clojure/ClojureScript files in the directory trees in `dirs`"
+  [dirs]
   (map str
        (filter
          #(and
-            (.isFile %1)
-            (.endsWith (str %1) ".clj"))
+           (.isFile %1)
+           (ends-with-one-of clojure-extensions (str %1)))
          (mapcat file-seq (map (fn [s] (java.io.File. s)) dirs)))))
 
-(defn mtime [f]
+(defn mtime
+  "Extract the last-modified time for this file"
+  [f]
   (.lastModified (java.io.File. f)))
 
-(defn take-directory-snapshot [dirs]
+(defn take-directory-snapshot
+  "Grab a snapshot of the directory now, to see what's changed
+   in the future."
+  [dirs]
   (apply
     str
     (map
@@ -21,7 +43,9 @@
         (format "%s:%s\n" f (mtime f)))
       (source-files-seq dirs))))
 
-(def target-directory (ref "docs/"))
+(def target-directory
+  "Where are we putting the output document?"
+  (ref "docs/"))
 
 (defn eval-in-project
   "Support eval-in-project in both Leiningen 1.x and 2.x."
@@ -37,9 +61,13 @@
       (eip project form init)
       (eip project form nil nil init))))
 
-(def dep ['lein-marginalia "0.7.1"])
+(def dep
+  "Dependencies to add to project in order to run *Marginalia*"
+  ['lein-marginalia "0.9.0"])
 
-(defn- add-marg-dep [project]
+(defn- add-marg-dep
+  "Temporarily add a dependency to *Marginalia* to the project"
+  [project]
   ;; Leiningen 2 is a bit smarter about only conjing it in if it
   ;; doesn't already exist and warning the user.
   (if-let [conj-dependency (resolve 'leiningen.core.project/conj-dependency)]

--- a/src/leiningen/margauto.clj
+++ b/src/leiningen/margauto.clj
@@ -1,8 +1,5 @@
 (ns leiningen.margauto
-  "Automatically update Marginalia-generated documentation.
-
-  Monitor Clojure and ClojureScript files in specified directories,
-  updating at intervals when a source file changes."
+  "Automatically update Marginalia-generated documentation."
   (:require [leiningen.marg :as lm]
             [clojure.tools.cli :as cli]))
 


### PR DESCRIPTION
You may only want to apply the changes from `margauto.clj` which broaden the `filter` to look for `.cljs` and `.cljc` files, too.

I pulled from _your_ fork since it was what I was using, rather than the original from Kyle.

I hope you find this helpful.
